### PR TITLE
Hotfix for change to mbedtls repo

### DIFF
--- a/recipes-connectivity/parsec-se-driver/parsec-se-driver_0.6.0.bb
+++ b/recipes-connectivity/parsec-se-driver/parsec-se-driver_0.6.0.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 
 inherit cargo
 SRC_URI = "git://github.com/parallaxsecond/parsec-se-driver.git;protocol=https;branch=main \
-           git://github.com/ARMmbed/mbedtls.git;protocol=https;destsuffix=mbedtls;name=mbedtls;branch=development_2.x"
+           git://github.com/ARMmbed/mbedtls.git;protocol=https;destsuffix=mbedtls;name=mbedtls;branch=archive/development_2.x"
 
 SRCREV_pn-${PN} = "${PV}"
 SRCREV_mbedtls = "mbedtls-2.27.0"


### PR DESCRIPTION
The upstream repo branch name has changed - it has been moved into an archive.