### PR TITLE
Add https protocol to GitHub fetches

### DIFF
--- a/recipes-connectivity/mbed-edge-core/mbed-edge-core.inc
+++ b/recipes-connectivity/mbed-edge-core/mbed-edge-core.inc
@@ -10,7 +10,7 @@ SRCREV = "0.19.1"
 
 RM_WORK_EXCLUDE += "${PN}"
 
-SRC_URI = "gitsm://github.com/PelionIoT/mbed-edge.git \
+SRC_URI = "gitsm://git@github.com/PelionIoT/mbed-edge.git;protocol=https \
            file://toolchain.cmake \
            file://mbed_cloud_client_user_config.h \
            file://0001-disable-Doxygen.patch \

--- a/recipes-connectivity/mbed-edge-examples/mbed-edge-examples.bb
+++ b/recipes-connectivity/mbed-edge-examples/mbed-edge-examples.bb
@@ -8,7 +8,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRCREV = "0.16.0"
 
-SRC_URI = "git://github.com/PelionIoT/mbed-edge-examples.git \
+SRC_URI = "git://git@github.com/PelionIoT/mbed-edge-examples.git;protocol=https \
            file://pt-example \
            file://blept-example \
            file://blept-devices.json \


### PR DESCRIPTION
GitHub has now brownouted non-secure git downloads, thus it's better
to use https protocol to avoid the issues.

https://github.blog/2021-09-01-improving-git-protocol-security-github/

```
NOTE: Executing Tasks
ERROR: mbed-edge-core-uz-1.0-r0 do_fetch: Fetcher failure: Fetch command export PSEUDO_DISABLED=1; export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/1000/bus"; export SSH_AGENT_PID="1979"; export SSH_AUTH_SOCK="/run/user/1000/keyring/ssh"; export PATH="/home/jannek/build/build-lmp/tmp-lmp/work/cortexa53-lmp-linux/mbed-edge-core-uz/1.0-r0/recipe-sysroot-native/usr/bin/python3-native:/home/jannek/build/layers/openembedded-core/scripts:/home/jannek/build/build-lmp/tmp-lmp/work/cortexa53-lmp-linux/mbed-edge-core-uz/1.0-r0/recipe-sysroot-native/usr/bin/aarch64-lmp-linux:/home/jannek/build/build-lmp/tmp-lmp/work/cortexa53-lmp-linux/mbed-edge-core-uz/1.0-r0/recipe-sysroot/usr/bin/crossscripts:/home/jannek/build/build-lmp/tmp-lmp/work/cortexa53-lmp-linux/mbed-edge-core-uz/1.0-r0/recipe-sysroot-native/usr/sbin:/home/jannek/build/build-lmp/tmp-lmp/work/cortexa53-lmp-linux/mbed-edge-core-uz/1.0-r0/recipe-sysroot-native/usr/bin:/home/jannek/build/build-lmp/tmp-lmp/work/cortexa53-lmp-linux/mbed-edge-core-uz/1.0-r0/recipe-sysroot-native/sbin:/home/jannek/build/build-lmp/tmp-lmp/work/cortexa53-lmp-linux/mbed-edge-core-uz/1.0-r0/recipe-sysroot-native/bin:/home/jannek/build/bitbake/bin:/home/jannek/build/build-lmp/tmp-lmp/hosttools"; export HOME="/home/jannek"; git -c core.fsyncobjectfiles=0 ls-remote git://github.com/PelionIoT/mbed-edge.git  failed with exit code 128, output:
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

ERROR: Logfile of failure stored in: /home/jannek/build/build-lmp/tmp-lmp/work/cortexa53-lmp-linux/mbed-edge-core-uz/1.0-r0/temp/log.do_fetch.2404533
ERROR: Task (/home/jannek/build/build-lmp/conf/../../layers/meta-mbed-edge/recipes-connectivity/mbed-edge-core/mbed-edge-core-uz.bb:do_fetch) failed with exit code '1'

```
